### PR TITLE
#13 echo example polyfills

### DIFF
--- a/examples/echo/index.html
+++ b/examples/echo/index.html
@@ -111,7 +111,9 @@
 
 </div>
 
-<script src="./dist/websockhop.js"></script>
+<script src="//cdn.jsdelivr.net/sockjs/1/sockjs.min.js"></script>
+<script src="./node_modules/engine.io-as-websocket/dist/engine.io-as-websocket.min.js"></script>
+<script src="./node_modules/dist/websockhop.js"></script>
 
 <script>
     (function() {

--- a/examples/echo/index.html
+++ b/examples/echo/index.html
@@ -35,6 +35,21 @@
     </section>
 
     <section>
+        <div class="form-group">
+            <label for="socket_type">Connect using</label>
+            <select id="socket_type">
+                <option value="websocket" selected>WebSocket</option>
+                <option value="sockjs">SockJS</option>
+                <option value="engineio">Engine.IO-as-WebSocket</option>
+            </select>
+        </div>
+        <div class="form-group">
+            <label for="url">Connect to URL</label>
+            <input type="text" id="url" class="form-control" />
+        </div>
+    </section>
+
+    <section>
         <h4>WebSockHop Status</h4>
         <div id="status"></div>
         <button id="switch" class="btn btn-default"></button>
@@ -113,10 +128,42 @@
 
 <script src="//cdn.jsdelivr.net/sockjs/1/sockjs.min.js"></script>
 <script src="./node_modules/engine.io-as-websocket/dist/engine.io-as-websocket.min.js"></script>
-<script src="./node_modules/dist/websockhop.js"></script>
+<script src="./node_modules/websockhop/dist/websockhop.js"></script>
 
 <script>
     (function() {
+
+        var types = {
+            "websocket": {
+                label: "WebSocket",
+                defaultUrl: "wss://echo.websocket.org/"
+            },
+            "sockjs": {
+                label: "SockJS",
+                defaultUrl: "http://localhost:9999/echo",
+                createSocket: function(url) {
+                    return new SockJS(url);
+                }
+            },
+            "engineio": {
+                label: "Engine.IO-as-WebSocket",
+                defaultUrl: "ws://localhost:3000",
+                createSocket: function(url) {
+                    return new EngineIoSocket(url);
+                }
+            }
+        };
+
+        var socketType = document.querySelector("#socket_type");
+        var urlField = document.querySelector("#url");
+
+        var getCurrentUrl = function() {
+            return urlField.value;
+        };
+        var getCurrentSocketTypeInfo = function() {
+            var type = socketType.value;
+            return types[type];
+        };
 
         // 0 - no async
         // 1 - use this.async() for async
@@ -155,10 +202,18 @@
             console.log("clicked " + switchButton.innerHTML);
 
             switch(state) {
-            case STATE_NO_SOCKET:
-                ws = new WebSockHop("wss://echo.websocket.org/");
+            case STATE_NO_SOCKET: {
+                var currentUrl = getCurrentUrl();
+                var currentTypeInfo = getCurrentSocketTypeInfo();
+
+                if (currentUrl == null || currentUrl === "") {
+                    alert("We need an URL to connect to.");
+                }
+
+                ws = new WebSockHop(currentUrl, { createSocket: currentTypeInfo.createSocket });
+
                 ws.formatter = new WebSockHop.JsonFormatter();
-                ws.formatter.pingRequest = { type: 'ping' };
+                ws.formatter.pingRequest = { type:'ping' };
                 ws.pingIntervalMsecs = 60000; // Change this to experiment with ping interval
                 ws.pingResponseTimeoutMsecs = 10000; // Change this to experiment with ping response timeout
                 ws.on('opening', function() {
@@ -258,6 +313,7 @@
                     addMessageToList("#echo", obj);
                 });
                 break;
+            }
 
             case STATE_WAITING_TO_OPEN:
             case STATE_WAITING_TO_RETRY:
@@ -350,6 +406,16 @@
             event.preventDefault();
         });
 
+        var updateSocketType = function(type) {
+            var socketTypeInfo = types[type];
+            urlField.value = socketTypeInfo.defaultUrl;
+        };
+
+        socketType.addEventListener("change", function(e) {
+            updateSocketType(e.target.value);
+        });
+        updateSocketType("websocket");
+
         var status = document.querySelector("#status");
         var sendButton = document.querySelector("#sendButton");
         var sendButton2 = document.querySelector("#sendButton2");
@@ -357,10 +423,15 @@
 
         var updateUi = function() {
 
+            var info = getCurrentSocketTypeInfo();
+            var url = getCurrentUrl();
+
             switch(state) {
             case STATE_NO_SOCKET:
                 status.innerHTML = "WebSockHop is not initialized.";
                 switchButton.innerHTML = "Connect";
+                socketType.disabled = false;
+                urlField.disabled = false;
                 sendButton.disabled = true;
                 sendButton2.disabled = true;
                 sendButton3.disabled = true;
@@ -368,20 +439,26 @@
             case STATE_WAITING_TO_OPEN:
                 status.innerHTML = "WebSockHop is waiting to open.";
                 switchButton.innerHTML = "Cancel";
+                socketType.disabled = true;
+                urlField.disabled = true;
                 sendButton.disabled = true;
                 sendButton2.disabled = true;
                 sendButton3.disabled = true;
                 break;
             case STATE_WAITING_TO_CONNECT:
-                status.innerHTML = "WebSockHop is initialized, now connecting ...";
+                status.innerHTML = "WebSockHop is initialized, now connecting to <code>" + url + "</code> using <strong>" + info.label + "</strong> ...";
                 switchButton.innerHTML = "Abort connect";
+                socketType.disabled = true;
+                urlField.disabled = true;
                 sendButton.disabled = true;
                 sendButton2.disabled = true;
                 sendButton3.disabled = true;
                 break;
             case STATE_CONNECTED:
-                status.innerHTML = "WebSockHop is initialized and connected.";
+                status.innerHTML = "WebSockHop is initialized and connected to <code>" + url + "</code> using <strong>" + info.label + "</strong>.";
                 switchButton.innerHTML = "Disconnect";
+                socketType.disabled = true;
+                urlField.disabled = true;
                 sendButton.disabled = false;
                 sendButton2.disabled = false;
                 sendButton3.disabled = false;
@@ -389,6 +466,8 @@
             case STATE_WAITING_TO_RETRY:
                 status.innerHTML = "WebSockHop is waiting to reconnect ...";
                 switchButton.innerHTML = "Abort reconnect";
+                socketType.disabled = true;
+                urlField.disabled = true;
                 sendButton.disabled = true;
                 sendButton2.disabled = true;
                 sendButton3.disabled = true;

--- a/examples/echo/index.html
+++ b/examples/echo/index.html
@@ -208,12 +208,13 @@
 
                 if (currentUrl == null || currentUrl === "") {
                     alert("We need an URL to connect to.");
+                    break;
                 }
 
                 ws = new WebSockHop(currentUrl, { createSocket: currentTypeInfo.createSocket });
 
                 ws.formatter = new WebSockHop.JsonFormatter();
-                ws.formatter.pingRequest = { type:'ping' };
+                ws.formatter.pingRequest = { type: 'ping' };
                 ws.pingIntervalMsecs = 60000; // Change this to experiment with ping interval
                 ws.pingResponseTimeoutMsecs = 10000; // Change this to experiment with ping response timeout
                 ws.on('opening', function() {

--- a/examples/echo/package.json
+++ b/examples/echo/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "websockhop-echo-example",
+  "version": "0.0.1",
+  "private": true,
+  "dependencies": {
+    "websockhop": "^2.0.0",
+    "engine.io-as-websocket": "^1.0.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "clean": "rimraf lib dist",
     "build": "npm run build:commonjs && npm run build:umd && npm run build:umd:min",
-    "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib --presets es2015 --plugins transform-async-to-generator,transform-runtime",
+    "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib --presets es2015 --plugins transform-object-rest-spread,transform-async-to-generator,transform-runtime,transform-function-bind",
     "build:umd": "mkdir -p dist && cross-env BABEL_ENV=browserify NODE_ENV=development browserify src/browser.js -s WebSockHop -o dist/websockhop.js -t [ babelify --presets [ es2015 ] --plugins [ transform-async-to-generator transform-runtime ] ]",
     "build:umd:min": "mkdir -p dist && cross-env BABEL_ENV=browserify NODE_ENV=production browserify src/browser.js -s WebSockHop -o dist/websockhop.min.js -t [ babelify --presets [ es2015 ] --plugins [ transform-async-to-generator transform-runtime ] ] -p [ minifyify --no-map ]",
     "check:src": "npm run lint",
@@ -39,6 +39,8 @@
     "babel-cli": "^6.9.0",
     "babel-eslint": "^6.0.4",
     "babel-plugin-transform-async-to-generator": "^6.8.0",
+    "babel-plugin-transform-function-bind": "^6.8.0",
+    "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-plugin-transform-runtime": "^6.9.0",
     "babel-preset-es2015": "^6.9.0",
     "babelify": "^7.3.0",

--- a/src/WebSockHop.js
+++ b/src/WebSockHop.js
@@ -409,29 +409,26 @@ class WebSockHop {
             }
         }
     }
-}
+    static isAvailable() {
+        if (isWebSocketUnavailable()) {
+            return false;
+        }
 
-Object.assign(WebSockHop, {
-    disable: { oldSafari: true, mobile: true },
-    isAvailable() {
-        if (isWebSocketUnavailable) {
+        if (this.disable.oldSafari && isInvalidSafari()) {
             return false;
         }
-    
-        if (this.disable.oldSafari && isInvalidSafari) {
+
+        if (this.disable.mobile && isMobile()) {
             return false;
         }
-    
-        if (this.disable.mobile && isMobile) {
-            return false;
-        }
-    
+
         return true;
-    },
-    ErrorEnumValue,
-    StringFormatter,
-    JsonFormatter,
-    MessageFormatterBase
-});
+    }
+}
+WebSockHop.disable = { oldSafari: true, mobile: true };
+WebSockHop.ErrorEnumValue = ErrorEnumValue;
+WebSockHop.StringFormatter = StringFormatter;
+WebSockHop.JsonFormatter = JsonFormatter;
+WebSockHop.MessageFormatterBase = MessageFormatterBase;
 
 export default WebSockHop; 

--- a/src/browserDetection.js
+++ b/src/browserDetection.js
@@ -39,24 +39,24 @@ const browser = detectBrowser();
 
 // WebSockets unavailable under certain conditions
 
-const isWebSocketUnavailable = (function() {
+function isWebSocketUnavailable() {
     return !("WebSocket" in window);
-})();
+}
 
-const isInvalidSafari = (function() {
+function isInvalidSafari() {
     return (
         browser.safari &&
         !browser.chrome &&
         parseFloat(browser.version) < 534.54
     );
-})();
+}
 
 function detectMobile(a) {
     return /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i.test(a)||/1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(a.substr(0,4));
 }
 
-const isMobile = (function() {
+function isMobile() {
     return detectMobile(navigator.userAgent||navigator.vendor||window.opera);
-})();
+}
 
 export { isWebSocketUnavailable, isInvalidSafari, isMobile };


### PR DESCRIPTION
This is for Issue #13, adding ability to choose a polyfill when running the echo example.

The echo example has been moved to a subdirectory inside the app so that it can have its own runtime node modules.

To run, switch to the examples/echo subdirectory and run install, then open the index.html file in a browser.