### PR TITLE
#13 echo example polyfills

### DIFF
--- a/examples/echo/index.html
+++ b/examples/echo/index.html
@@ -111,7 +111,9 @@
 
 </div>
 
-<script src="./dist/websockhop.js"></script>
+<script src="//cdn.jsdelivr.net/sockjs/1/sockjs.min.js"></script>
+<script src="./node_modules/engine.io-as-websocket/dist/engine.io-as-websocket.min.js"></script>
+<script src="./node_modules/dist/websockhop.js"></script>
 
 <script>
     (function() {

--- a/examples/echo/index.html
+++ b/examples/echo/index.html
@@ -35,6 +35,21 @@
     </section>
 
     <section>
+        <div class="form-group">
+            <label for="socket_type">Connect using</label>
+            <select id="socket_type">
+                <option value="websocket" selected>WebSocket</option>
+                <option value="sockjs">SockJS</option>
+                <option value="engineio">Engine.IO-as-WebSocket</option>
+            </select>
+        </div>
+        <div class="form-group">
+            <label for="url">Connect to URL</label>
+            <input type="text" id="url" class="form-control" />
+        </div>
+    </section>
+
+    <section>
         <h4>WebSockHop Status</h4>
         <div id="status"></div>
         <button id="switch" class="btn btn-default"></button>
@@ -113,10 +128,42 @@
 
 <script src="//cdn.jsdelivr.net/sockjs/1/sockjs.min.js"></script>
 <script src="./node_modules/engine.io-as-websocket/dist/engine.io-as-websocket.min.js"></script>
-<script src="./node_modules/dist/websockhop.js"></script>
+<script src="./node_modules/websockhop/dist/websockhop.js"></script>
 
 <script>
     (function() {
+
+        var types = {
+            "websocket": {
+                label: "WebSocket",
+                defaultUrl: "wss://echo.websocket.org/"
+            },
+            "sockjs": {
+                label: "SockJS",
+                defaultUrl: "http://localhost:9999/echo",
+                createSocket: function(url) {
+                    return new SockJS(url);
+                }
+            },
+            "engineio": {
+                label: "Engine.IO-as-WebSocket",
+                defaultUrl: "ws://localhost:3000",
+                createSocket: function(url) {
+                    return new EngineIoSocket(url);
+                }
+            }
+        };
+
+        var socketType = document.querySelector("#socket_type");
+        var urlField = document.querySelector("#url");
+
+        var getCurrentUrl = function() {
+            return urlField.value;
+        };
+        var getCurrentSocketTypeInfo = function() {
+            var type = socketType.value;
+            return types[type];
+        };
 
         // 0 - no async
         // 1 - use this.async() for async
@@ -155,10 +202,18 @@
             console.log("clicked " + switchButton.innerHTML);
 
             switch(state) {
-            case STATE_NO_SOCKET:
-                ws = new WebSockHop("wss://echo.websocket.org/");
+            case STATE_NO_SOCKET: {
+                var currentUrl = getCurrentUrl();
+                var currentTypeInfo = getCurrentSocketTypeInfo();
+
+                if (currentUrl == null || currentUrl === "") {
+                    alert("We need an URL to connect to.");
+                }
+
+                ws = new WebSockHop(currentUrl, { createSocket: currentTypeInfo.createSocket });
+
                 ws.formatter = new WebSockHop.JsonFormatter();
-                ws.formatter.pingRequest = { type: 'ping' };
+                ws.formatter.pingRequest = { type:'ping' };
                 ws.pingIntervalMsecs = 60000; // Change this to experiment with ping interval
                 ws.pingResponseTimeoutMsecs = 10000; // Change this to experiment with ping response timeout
                 ws.on('opening', function() {
@@ -258,6 +313,7 @@
                     addMessageToList("#echo", obj);
                 });
                 break;
+            }
 
             case STATE_WAITING_TO_OPEN:
             case STATE_WAITING_TO_RETRY:
@@ -350,6 +406,16 @@
             event.preventDefault();
         });
 
+        var updateSocketType = function(type) {
+            var socketTypeInfo = types[type];
+            urlField.value = socketTypeInfo.defaultUrl;
+        };
+
+        socketType.addEventListener("change", function(e) {
+            updateSocketType(e.target.value);
+        });
+        updateSocketType("websocket");
+
         var status = document.querySelector("#status");
         var sendButton = document.querySelector("#sendButton");
         var sendButton2 = document.querySelector("#sendButton2");
@@ -357,10 +423,15 @@
 
         var updateUi = function() {
 
+            var info = getCurrentSocketTypeInfo();
+            var url = getCurrentUrl();
+
             switch(state) {
             case STATE_NO_SOCKET:
                 status.innerHTML = "WebSockHop is not initialized.";
                 switchButton.innerHTML = "Connect";
+                socketType.disabled = false;
+                urlField.disabled = false;
                 sendButton.disabled = true;
                 sendButton2.disabled = true;
                 sendButton3.disabled = true;
@@ -368,20 +439,26 @@
             case STATE_WAITING_TO_OPEN:
                 status.innerHTML = "WebSockHop is waiting to open.";
                 switchButton.innerHTML = "Cancel";
+                socketType.disabled = true;
+                urlField.disabled = true;
                 sendButton.disabled = true;
                 sendButton2.disabled = true;
                 sendButton3.disabled = true;
                 break;
             case STATE_WAITING_TO_CONNECT:
-                status.innerHTML = "WebSockHop is initialized, now connecting ...";
+                status.innerHTML = "WebSockHop is initialized, now connecting to <code>" + url + "</code> using <strong>" + info.label + "</strong> ...";
                 switchButton.innerHTML = "Abort connect";
+                socketType.disabled = true;
+                urlField.disabled = true;
                 sendButton.disabled = true;
                 sendButton2.disabled = true;
                 sendButton3.disabled = true;
                 break;
             case STATE_CONNECTED:
-                status.innerHTML = "WebSockHop is initialized and connected.";
+                status.innerHTML = "WebSockHop is initialized and connected to <code>" + url + "</code> using <strong>" + info.label + "</strong>.";
                 switchButton.innerHTML = "Disconnect";
+                socketType.disabled = true;
+                urlField.disabled = true;
                 sendButton.disabled = false;
                 sendButton2.disabled = false;
                 sendButton3.disabled = false;
@@ -389,6 +466,8 @@
             case STATE_WAITING_TO_RETRY:
                 status.innerHTML = "WebSockHop is waiting to reconnect ...";
                 switchButton.innerHTML = "Abort reconnect";
+                socketType.disabled = true;
+                urlField.disabled = true;
                 sendButton.disabled = true;
                 sendButton2.disabled = true;
                 sendButton3.disabled = true;

--- a/examples/echo/index.html
+++ b/examples/echo/index.html
@@ -208,12 +208,13 @@
 
                 if (currentUrl == null || currentUrl === "") {
                     alert("We need an URL to connect to.");
+                    break;
                 }
 
                 ws = new WebSockHop(currentUrl, { createSocket: currentTypeInfo.createSocket });
 
                 ws.formatter = new WebSockHop.JsonFormatter();
-                ws.formatter.pingRequest = { type:'ping' };
+                ws.formatter.pingRequest = { type: 'ping' };
                 ws.pingIntervalMsecs = 60000; // Change this to experiment with ping interval
                 ws.pingResponseTimeoutMsecs = 10000; // Change this to experiment with ping response timeout
                 ws.on('opening', function() {

--- a/examples/echo/package.json
+++ b/examples/echo/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "websockhop-echo-example",
+  "version": "0.0.1",
+  "private": true,
+  "dependencies": {
+    "websockhop": "^2.0.0",
+    "engine.io-as-websocket": "^1.0.0"
+  }
+}


### PR DESCRIPTION
Doing this again, since I accidenally applied #15 to the wrong branch.

This is for Issue #13, adding ability to choose a polyfill when running the echo example.

The echo example has been moved to a subdirectory inside the app so that it can have its own runtime node modules.

To run, switch to the examples/echo subdirectory and run install, then open the index.html file in a browser.