### PR TITLE
Issues 20 21

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "clean": "rimraf lib dist",
     "build": "npm run build:commonjs && npm run build:umd && npm run build:umd:min",
     "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib --presets es2015 --plugins transform-object-rest-spread,transform-async-to-generator,transform-runtime,transform-function-bind",
-    "build:umd": "mkdirp dist && cross-env BABEL_ENV=browserify NODE_ENV=development browserify src/browser.js -s WebSockHop -o dist/websockhop.js -t [ babelify --presets [ es2015 ] --plugins [ transform-object-rest-spread transform-async-to-generator transform-runtime transform-function-bind transform-inline-environment-variables ] ]",
+    "build:umd": "mkdirp dist && cross-env BABEL_ENV=browserify NODE_ENV=development browserify src/browser.js -s WebSockHop -t [ babelify --presets [ es2015 ] --plugins [ transform-object-rest-spread transform-async-to-generator transform-runtime transform-function-bind transform-inline-environment-variables ] ] -d | exorcist dist/websockhop.js.map > dist/websockhop.js",
     "build:umd:min": "mkdirp dist && cross-env BABEL_ENV=browserify NODE_ENV=production browserify src/browser.js -s WebSockHop -o dist/websockhop.min.js -t [ babelify --presets [ es2015 ] --plugins [ transform-object-rest-spread transform-async-to-generator transform-runtime transform-function-bind transform-inline-environment-variables ] ] -p [ minifyify --no-map ]",
     "check:src": "npm run lint",
     "lint": "eslint src",
@@ -48,6 +48,7 @@
     "browserify": "^13.0.1",
     "cross-env": "^1.0.7",
     "eslint": "^2.10.2",
+    "exorcist": "^0.4.0",
     "minifyify": "^7.3.3",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.5.2"


### PR DESCRIPTION
Fixes #20 and #21 by changing how a WebSockHop 'clears' a websocket on _raiseErrorEvent. Previously, it would just set `this.socket = null`, and eventually create a new socket soon after. If the socket ever received more messages in the future, they would be passed to dispatchMessage and exceptions could occur.

With this change, instead of just nulling out the old socket, a new func `_clearSocket()` is called, which not only nulls out the socket but also nulls out event handlers on the socket as well as some other private state. It also calls `.close()` on the underlying socket so the server doesn't end up having more than one socket open for a single WebSocketHop instance.

@harmony7 if you're around, this pull could benefit from your review.

One implication of this change is that once a socket is 'cleared' due to 'raiseErrorEvent', any messages that come out of that socket will be ignored. Technically that was not the case before, but I'm pretty sure it could lead to bad behaviors, as the rest of the internal state around ping/ponging and connection timeouts only accounts for a single underlying socket.

**Other changes**

* `npm run build` now creates a source map for `dist/websockhop.js` as `dist/websockhop.js.map`, becausing debugging it in the browser is unreasonably difficult without source maps.

**How do temporarily disrupt connections on Mac** (where there is no `iptables`):
Use `pfctl`.

To temporarily block connections to local port 3000 (like for examples/echo):
```
(sudo pfctl -sr 2>/dev/null; echo "block drop quick on lo0 proto tcp from any to any port = 3000") | sudo pfctl -e -f - 2>/dev/null
```
To re-enable connections by re-loading pfctl configuration from default config file:
```
sudo pfctl -f /etc/pf.conf
```
(Thanks to [jaume](https://superuser.com/a/505209))