### PR TITLE
Use mkdirp for Windows support

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "clean": "rimraf lib dist",
     "build": "npm run build:commonjs && npm run build:umd && npm run build:umd:min",
     "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib --presets es2015 --plugins transform-object-rest-spread,transform-async-to-generator,transform-runtime,transform-function-bind",
-    "build:umd": "mkdir -p dist && cross-env BABEL_ENV=browserify NODE_ENV=development browserify src/browser.js -s WebSockHop -o dist/websockhop.js -t [ babelify --presets [ es2015 ] --plugins [ transform-object-rest-spread transform-async-to-generator transform-runtime transform-function-bind transform-inline-environment-variables ] ]",
-    "build:umd:min": "mkdir -p dist && cross-env BABEL_ENV=browserify NODE_ENV=production browserify src/browser.js -s WebSockHop -o dist/websockhop.min.js -t [ babelify --presets [ es2015 ] --plugins [ transform-object-rest-spread transform-async-to-generator transform-runtime transform-function-bind transform-inline-environment-variables ] ] -p [ minifyify --no-map ]",
+    "build:umd": "mkdirp dist && cross-env BABEL_ENV=browserify NODE_ENV=development browserify src/browser.js -s WebSockHop -o dist/websockhop.js -t [ babelify --presets [ es2015 ] --plugins [ transform-object-rest-spread transform-async-to-generator transform-runtime transform-function-bind transform-inline-environment-variables ] ]",
+    "build:umd:min": "mkdirp dist && cross-env BABEL_ENV=browserify NODE_ENV=production browserify src/browser.js -s WebSockHop -o dist/websockhop.min.js -t [ babelify --presets [ es2015 ] --plugins [ transform-object-rest-spread transform-async-to-generator transform-runtime transform-function-bind transform-inline-environment-variables ] ] -p [ minifyify --no-map ]",
     "check:src": "npm run lint",
     "lint": "eslint src",
     "prepublish": "npm run clean && npm run check:src && npm run build"
@@ -49,6 +49,7 @@
     "cross-env": "^1.0.7",
     "eslint": "^2.10.2",
     "minifyify": "^7.3.3",
+    "mkdirp": "^0.5.1",
     "rimraf": "^2.5.2"
   },
   "dependencies": {


### PR DESCRIPTION
Use mkdirp from npm instead of 'mkdir -p' in npm build scripts. Should help with Windows support and resolve #22 