### PR TITLE
Release to npmjs using updated CI workflow and trusted publishing

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -2,52 +2,19 @@ name: Release CI
 on:
   push:
     tags:
-      # This looks like a regex, but it's actually a filter pattern
-      # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
-      - 'v*.*.*'
-      - 'v*.*.*-*'
+      - 'v*'
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
-  release:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: "Checkout code"
-        uses: actions/checkout@v4
-
-      - name: Validate SemVer tag
-        run: |
-          TAG="${GITHUB_REF_NAME#refs/tags/}"
-          if [[ ! "$TAG" =~ ^v[0-9]+(\.[0-9]+){2}(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
-            echo "::error::Invalid tag: $TAG. Must follow SemVer syntax (e.g., v1.2.3, v1.2.3-alpha)."
-            exit 1
-          fi
-        shell: bash
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 'lts/*'
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Extract prerelease tag if present
-        id: extract-tag
-        run: |
-          TAG="${GITHUB_REF_NAME#v}" # Remove the "v" prefix
-          if [[ "$TAG" == *-* ]]; then
-            PRERELEASE=${TAG#*-} # Remove everything before the dash
-            PRERELEASE=${PRERELEASE%%.*} # Remove everything after the first period
-          else
-            PRERELEASE="latest"
-          fi
-          echo "DIST_TAG=$PRERELEASE" >> $GITHUB_ENV
-
-      - name: Install npm dependencies
-        run: npm install
-
-      - name: Publish to npmjs.org
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          echo "Publishing to npmjs.org using dist-tag: $DIST_TAG"
-          npm publish --access=public --tag "$DIST_TAG"
+  process-version:
+    uses: fastly/devex-reusable-workflows/.github/workflows/process-semver-v1.yml@main
+  publish_npm:
+    needs: process-version
+    uses: fastly/devex-reusable-workflows/.github/workflows/publish-javascript-npmjs-v1.yml@main
+    with:
+      expected_pkg_name: "websockhop"
+      expected_pkg_version: ${{ needs.process-version.outputs.version }}
+      dist_tag: ${{ needs.process-version.outputs.dist_tag }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 WebSockHop Changelog
 ====================
 
+  * Release to npmjs using updated CI workflow and trusted publishing
+
 v. 2.2.2 (02-17-2025)
 
   * Clean up build scripts


### PR DESCRIPTION
This PR updates the package's release process to npmjs to use the reusable workflows that live in https://github.com/fastly/devex-reusable-workflows.

* Workflow triggers whenever a tag that starts with `v` is pushed.

* [process-semver-v1.yml](https://github.com/fastly/devex-reusable-workflows?tab=readme-ov-file#process-semver-v1yml)
   * processes the pushed tag to see if it looks like a semver

* [publish-javascript-npmjs-v1.yml](https://github.com/fastly/devex-reusable-workflows?tab=readme-ov-file#publish-javascript-npmjs-v1yml)
   * publishes the package to npmjs.org
